### PR TITLE
refactor(throttle)!: use maps instead of objects

### DIFF
--- a/lib/core/boot/boot.spec.ts
+++ b/lib/core/boot/boot.spec.ts
@@ -110,6 +110,7 @@ describe(bootstrap.name, () => {
 		expect(server.pendingWebSockets).toEqual(0);
 		expect(server.routes).toBeArray();
 		expect(server.cache).toBeArrayOfSize(0);
+		expect(server.throttle).toBeInstanceOf(Map);
 		expect(server.fetch).toBeInstanceOf(Function);
 		expect(server.upgrade).toBeInstanceOf(Function);
 		expect(server.publish).toBeInstanceOf(Function);

--- a/lib/core/boot/boot.ts
+++ b/lib/core/boot/boot.ts
@@ -87,7 +87,7 @@ export const bootstrap = (): FluxifyServer => {
 						if (config.throttleTtl === throttle.ttl && config.throttleLimit === throttle.limit) {
 							const globally = throttleLookup(global.server.throttle, criteria, 'globally', 'all', throttle.ttl);
 							if (globally.hits > config.throttleLimit) {
-								debug(`throttle limit on route ${endpoint}`);
+								debug(`throttle limit on route ${targetRoute.endpoint}`);
 								const status = 429;
 								stop(request, 'throttle');
 								return createResponse({ status, message: 'too many requests' }, status, request, {
@@ -97,7 +97,7 @@ export const bootstrap = (): FluxifyServer => {
 						} else {
 							const locally = throttleLookup(global.server.throttle, criteria, endpoint, method, throttle.ttl);
 							if (locally.hits > throttle.limit) {
-								debug(`throttle limit on route ${endpoint}`);
+								debug(`throttle limit on route ${targetRoute.endpoint}`);
 								const status = 429;
 								stop(request, 'throttle');
 								return createResponse({ status, message: 'too many requests' }, status, request, {

--- a/lib/throttle/throttle.spec.ts
+++ b/lib/throttle/throttle.spec.ts
@@ -1,12 +1,16 @@
-import { beforeAll, describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import { config } from '../config/config';
 import { Route } from '../router/router.type';
-import { throttleOptions } from './throttle';
+import { throttleLookup, throttleOptions } from './throttle';
 
-beforeAll(() => {
-	config.throttleTtl = 8;
-	config.throttleLimit = 4;
-});
+config.throttleTtl = 8;
+config.throttleLimit = 4;
+Date.now = mock(() => 42000);
+
+const criteria = '127.0.0.1';
+const endpoint = '/auth/me';
+const method = 'get';
+const entry = { exp: config.throttleTtl * 1000 + Date.now(), hits: 1 };
 
 describe(throttleOptions.name, () => {
 	test('should enable global throttle options by default', () => {
@@ -22,5 +26,61 @@ describe(throttleOptions.name, () => {
 	test('should disable custom throttle options when overriding them in route', () => {
 		const route = { schema: { throttle: { ttl: 0 } } } as Route;
 		expect(throttleOptions(route)).toEqual({ use: false, ttl: 0, limit: 4 });
+	});
+});
+
+describe(throttleLookup.name, () => {
+	test('should return a new entry given no entries in the throttle', () => {
+		const throttle = new Map();
+		expect(throttleLookup(throttle, criteria, endpoint, method, config.throttleTtl)).toEqual({
+			exp: Date.now() + config.throttleTtl * 1000,
+			hits: 1,
+		});
+	});
+
+	test('should return a new entry given no map children entries in the throttle', () => {
+		const throttle = new Map();
+		throttle.set(criteria, new Map());
+		expect(throttleLookup(throttle, criteria, endpoint, method, config.throttleTtl)).toEqual({
+			exp: Date.now() + config.throttleTtl * 1000,
+			hits: 1,
+		});
+	});
+
+	test('should return a new entry given no nested map children entries in the throttle', () => {
+		const endpoints = new Map();
+		endpoints.set(endpoint, new Map());
+		const throttle = new Map();
+		throttle.set(criteria, endpoints);
+		expect(throttleLookup(throttle, criteria, endpoint, method, config.throttleTtl)).toEqual({
+			exp: Date.now() + config.throttleTtl * 1000,
+			hits: 1,
+		});
+	});
+
+	test('should return an incremented entry given deeply nested map children entries in the throttle', () => {
+		const methods = new Map();
+		methods.set(method, entry);
+		const endpoints = new Map();
+		endpoints.set(endpoint, methods);
+		const throttle = new Map();
+		throttle.set(criteria, endpoints);
+		expect(throttleLookup(throttle, criteria, endpoint, method, config.throttleTtl)).toEqual({
+			exp: Date.now() + config.throttleTtl * 1000,
+			hits: 2,
+		});
+	});
+
+	test('should reset hits and return a new entry given deeply nested map children entries in the throttle', () => {
+		const methods = new Map();
+		methods.set(method, { ...entry, exp: Date.now() });
+		const endpoints = new Map();
+		endpoints.set(endpoint, methods);
+		const throttle = new Map();
+		throttle.set(criteria, endpoints);
+		expect(throttleLookup(throttle, criteria, endpoint, method, config.throttleTtl)).toEqual({
+			exp: Date.now() + config.throttleTtl * 1000,
+			hits: 1,
+		});
 	});
 });

--- a/lib/throttle/throttle.ts
+++ b/lib/throttle/throttle.ts
@@ -1,6 +1,6 @@
 import { config } from '../config/config';
-import { Route } from '../router/router.type';
-import { ThrottleOptions } from './throttle.type';
+import { Method, Route } from '../router/router.type';
+import { Throttle, ThrottleEntry, ThrottleOptions } from './throttle.type';
 
 export const throttleOptions = (route: Route | undefined): ThrottleOptions => {
 	const options: ThrottleOptions = { use: false, ttl: config.throttleTtl, limit: config.throttleLimit };
@@ -8,4 +8,31 @@ export const throttleOptions = (route: Route | undefined): ThrottleOptions => {
 	if (route?.schema?.throttle?.limit !== undefined) options.limit = route.schema.throttle.limit;
 	if (options.ttl > 0 && options.limit > 0) options.use = true;
 	return options;
+};
+
+export const throttleLookup = (
+	throttle: Throttle,
+	criteria: string,
+	endpoint: string,
+	method: Method,
+	ttl: number,
+): ThrottleEntry => {
+	if (!throttle.has(criteria)) {
+		throttle.set(criteria, new Map());
+	}
+	const criteriaEntry = throttle.get(criteria)!;
+	if (!criteriaEntry.has(endpoint)) {
+		criteriaEntry.set(endpoint, new Map());
+	}
+	const endpointEntry = criteriaEntry.get(endpoint)!;
+	if (!endpointEntry.has(method)) {
+		endpointEntry.set(method, { exp: Date.now() + ttl * 1000, hits: 0 });
+	}
+	const methodEntry = endpointEntry.get(method)!;
+	if (methodEntry.exp <= Date.now()) {
+		methodEntry.exp = Date.now() + ttl * 1000;
+		methodEntry.hits = 0;
+	}
+	methodEntry.hits += 1;
+	return methodEntry;
 };

--- a/lib/throttle/throttle.type.ts
+++ b/lib/throttle/throttle.type.ts
@@ -1,9 +1,9 @@
-type Entry = {
+export type ThrottleEntry = {
 	exp: number;
 	hits: number;
 };
 
-export type Throttle = Record<string, Record<string, Record<string, Entry>>>;
+export type Throttle = Map<string, Map<string, Map<string, ThrottleEntry>>>;
 
 export type ThrottleOptions = {
 	use: boolean;


### PR DESCRIPTION
This pull request reworks how the throttle works.
We now use maps instead of objects because of the better time complexity when accessing a key.
A small performance test show that this increases the raw throughput without any handler logic at around 7%.